### PR TITLE
Fix send_now return value

### DIFF
--- a/daily_fortune_service.py
+++ b/daily_fortune_service.py
@@ -85,7 +85,7 @@ class DailyFortuneService:
     def send_now(self):
         """立即发送运势（用于测试）"""
         print("🚀 立即发送每日运势...")
-        self.send_daily_fortune()
+        return self.send_daily_fortune()
 
 def main():
     """主函数"""


### PR DESCRIPTION
## Summary
- return status from `send_now` so callers know whether sending succeeded

## Testing
- `python -m py_compile daily_fortune_service.py`

------
https://chatgpt.com/codex/tasks/task_e_683fde2396d48321bbbb607bff4f3718